### PR TITLE
Untitled

### DIFF
--- a/basic/blog/templates/blog/post_detail.html
+++ b/basic/blog/templates/blog/post_detail.html
@@ -32,7 +32,7 @@
   {% tags_for_object object as tag_list %}
   {% if tag_list %}
   <p class="inline_tag_list"><strong>{% trans "Related tags" %}:</strong>
-    {{ tag_list|join", " }}
+    {{ tag_list|join:", " }}
   </p>
   {% endif %}
 


### PR DESCRIPTION
This fixes a template syntax error:

```
-    {{ tag_list|join", " }}
+    {{ tag_list|join:", " }}
```
