### PR TITLE
Template dirs in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,21 @@ for dirpath, dirnames, filenames in os.walk(package_dir):
     if "__init__.py" in filenames:
         packages.append(".".join(fullsplit(dirpath)))
 
+template_patterns = [
+    'templates/*.html',
+    'templates/*/*.html',
+    'templates/*/*/*.html',
+]
+
+package_data = dict(
+    (package_name, template_patterns)
+    for package_name in packages
+)
 
 setup(name='django-basic-apps',
     version='0.7',
     description='Django Basic Apps',
     author='Nathan Borror',
     url='http://github.com/nathanborror/django-basic-apps',
-    packages=packages)
+    packages=packages,
+    package_data=package_data)


### PR DESCRIPTION
Hi,
I modified setup.py to include the template dirs for each app. Before this, installing via pip would not include them since they weren't Python packages. Data files have to be explicitly included in setup.py. The way I did it is a little brittle, but should work with any Django project I've personally seen - maybe you know a better way, but it seems to work fine for basic-apps at least.
Thanks for your hard work on this!
Alex
