### PR TITLE
remove duplicate STOP_WORDS compliation

### DIFF
--- a/basic/blog/feeds.py
+++ b/basic/blog/feeds.py
@@ -1,7 +1,6 @@
-from django.contrib.syndication.feeds import FeedDoesNotExist
+from django.contrib.syndication.views import Feed, FeedDoesNotExist
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.sites.models import Site
-from django.contrib.syndication.feeds import Feed
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.comments.models import Comment
 from django.core.urlresolvers import reverse

--- a/basic/blog/views.py
+++ b/basic/blog/views.py
@@ -163,9 +163,8 @@ def search(request, template_name='blog/post_search.html'):
     """
     context = {}
     if request.GET:
-        stop_word_list = re.compile(STOP_WORDS_RE, re.IGNORECASE)
         search_term = '%s' % request.GET['q']
-        cleaned_search_term = stop_word_list.sub('', search_term)
+        cleaned_search_term = STOP_WORDS_RE.sub('', search_term)
         cleaned_search_term = cleaned_search_term.strip()
         if len(cleaned_search_term) != 0:
             post_list = Post.objects.published().filter(Q(title__icontains=cleaned_search_term) | Q(body__icontains=cleaned_search_term) | Q(tags__icontains=cleaned_search_term) | Q(categories__title__icontains=cleaned_search_term))


### PR DESCRIPTION
Hi Nathan, STOP_WORDS is compiled twice via re.compile().  Once in tools/constants.py and once in blog/views.py.  python2.5 doesn't mind, but python2.6 chokes on this.

This commit removes the second re.compile().  This works in both python2.5 and python2.6

This is also Issue #20.

Cheers, appreciate all your work on all these apps.  Great example of quality python and django.

Mike
