### PR TITLE
Fix searching blog posts.

### DIFF
--- a/basic/blog/views.py
+++ b/basic/blog/views.py
@@ -163,9 +163,8 @@ def search(request, template_name='blog/post_search.html'):
     """
     context = {}
     if request.GET:
-        stop_word_list = re.compile(STOP_WORDS_RE, re.IGNORECASE)
         search_term = '%s' % request.GET['q']
-        cleaned_search_term = stop_word_list.sub('', search_term)
+        cleaned_search_term = STOP_WORDS_RE.sub('', search_term)
         cleaned_search_term = cleaned_search_term.strip()
         if len(cleaned_search_term) != 0:
             post_list = Post.objects.published().filter(Q(title__icontains=cleaned_search_term) | Q(body__icontains=cleaned_search_term) | Q(tags__icontains=cleaned_search_term) | Q(categories__title__icontains=cleaned_search_term))


### PR DESCRIPTION
The search() view was passing STOP_WORDS_RE as a parameter to
re.compile().  Instead, just use STOP_WORDS_RE directly.
