### PR TITLE
Fixed thumbnail template tag to work with images with spaces in them or ...

### DIFF
--- a/basic/tools/templatetags/thumbnail.py
+++ b/basic/tools/templatetags/thumbnail.py
@@ -1,5 +1,7 @@
 from django import template
 from django.conf import settings
+import urllib
+
 register = template.Library()
 
 
@@ -23,7 +25,7 @@ def thumbnail(url, size='200x200'):
 
     if url.startswith(settings.MEDIA_URL):
         url = url[len(settings.MEDIA_URL):]
-    original_path = settings.MEDIA_ROOT + url
+    original_path = urllib.unquote(settings.MEDIA_ROOT + url)
 
     # Define the thumbnail's filename, file path, and URL.
     try:


### PR DESCRIPTION
...other url escapes (such as user uploaded photos)

Not sure if this was intentional or not, but in my use, the stored photos could have spaces in them that would be escaped in the url, but not the path, and needed to be unquoted. 
